### PR TITLE
Add progress estimate while collecting report

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -144,9 +144,9 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /**
  * Estimates how long it would take to generate a report for the given date range.
  * On average, it takes about 1.5 seconds per day of data.
- * @param {*} startIso 
- * @param {*} endIso 
- * @returns 
+ * @param {*} startIso
+ * @param {*} endIso
+ * @returns
  */
 function estimateDurationSeconds(startIso, endIso) {
   if (!startIso || !endIso) return 0;
@@ -427,7 +427,7 @@ function App() {
       }
     };
   }, [isLoading, estimatedDurationSeconds]);
-  
+
   useEffect(() => {
     if (!isLoading || estimatedDurationSeconds <= 0) {
       if (progressAnimationRef.current) {
@@ -534,16 +534,16 @@ function App() {
             type="submit"
             disabled=${!isFormValid}
           >
-            ${isLoading &&
-            html`<span
-              class="progress-fill"
-              style=${{ width: `${progressPercent}%` }}
-            ></span>`}
+            ${
+              isLoading &&
+              html`<span class="progress-fill" style=${{ width: `${progressPercent}%` }}></span>`
+            }
             <span class="button-label">
-              ${isLoading
-        ? `Collecting data...${progressPercent ? ` ${progressPercent}%` : ''}`
-        : 'Build Report'
-      }
+              ${
+                isLoading
+                  ? `Collecting data...${progressPercent ? ` ${progressPercent}%` : ''}`
+                  : 'Build Report'
+              }
             </span>
           </button>
           ${isLoading && progressLabel && html`<p class="loading-text">${progressLabel}</p>`}

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -110,6 +110,13 @@ function toggleBlackholeEffect(enabled) {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/**
+ * Estimates how long it would take to generate a report for the given date range.
+ * On average, it takes about 1.5 seconds per day of data.
+ * @param {*} startIso 
+ * @param {*} endIso 
+ * @returns 
+ */
 function estimateDurationSeconds(startIso, endIso) {
   if (!startIso || !endIso) return 0;
   const startMs = Date.parse(`${startIso}T00:00:00Z`);
@@ -119,8 +126,7 @@ function estimateDurationSeconds(startIso, endIso) {
   }
 
   const diffDays = Math.floor((endMs - startMs) / MS_PER_DAY);
-  const totalDays = diffDays + 1;
-  return Math.max(1, totalDays);
+  return Math.max(1, diffDays) * 1.5;
 }
 
 function formatTimeRemainingLabel(remainingSeconds, isPastEstimate) {
@@ -439,11 +445,10 @@ function App() {
 
         <div class="button-row">
           <button id="build-report-btn" class="primary" type="submit" disabled=${!isFormValid}>
-            ${
-              isLoading
-                ? `Collecting data...${progressPercent ? ` ${progressPercent}%` : ''}`
-                : 'Build Report'
-            }
+            ${isLoading
+      ? `Collecting data...${progressPercent ? ` ${progressPercent}%` : ''}`
+      : 'Build Report'
+    }
           </button>
           ${isLoading && progressLabel && html`<p class="loading-text">${progressLabel}</p>`}
           ${error && html`<p class="error-text">${error}</p>`}

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -144,6 +144,11 @@ button.primary:disabled {
   color: rgba(229, 236, 255, 0.66);
 }
 
+.loading-text {
+  font-size: 0.85rem;
+  color: rgba(229, 236, 255, 0.78);
+}
+
 .error-text {
   color: #ff8080;
   font-size: 0.82rem;

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -128,6 +128,11 @@ button.primary {
   box-shadow: 0 18px 40px rgba(11, 69, 255, 0.28);
 }
 
+button.primary .button-label {
+  position: relative;
+  z-index: 1;
+}
+
 button.primary:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 26px 60px rgba(11, 69, 255, 0.35);
@@ -137,6 +142,28 @@ button.primary:disabled {
   opacity: 0.45;
   cursor: not-allowed;
   box-shadow: none;
+}
+
+button.primary.loading {
+  position: relative;
+  overflow: hidden;
+}
+
+button.primary.loading .progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(135deg, rgba(20, 80, 255, 0.95), rgba(78, 141, 255, 0.82));
+  transition: width 200ms ease-out;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.95;
+}
+
+button.primary.loading:disabled {
+  opacity: 1;
+  cursor: wait;
+  box-shadow: 0 18px 40px rgba(11, 69, 255, 0.28);
 }
 
 .helper-text {


### PR DESCRIPTION
## Summary
- estimate the expected report build duration from the selected date range and start a countdown while the request runs
- surface the countdown with a faux progress percentage on the submit button plus friendly time-remaining messaging beneath it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17c2729208322a8e42937c9c79d3f