### PR TITLE
Add progress estimate to report builder

### DIFF
--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -144,6 +144,12 @@ button.primary:disabled {
   color: rgba(229, 236, 255, 0.66);
 }
 
+.progress-text {
+  font-size: 0.85rem;
+  color: rgba(229, 236, 255, 0.8);
+  font-style: italic;
+}
+
 .error-text {
   color: #ff8080;
   font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- estimate report duration from the selected date range and derive a friendly time-remaining message
- show the live estimate under the build button while a report is being generated
- add light styling for the inline progress text so it blends with the existing UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d17c2729208322a8e42937c9c79d3f